### PR TITLE
fix: update to support newer version of InfluxDB Python client

### DIFF
--- a/influxdb_dashboard/client.py
+++ b/influxdb_dashboard/client.py
@@ -1,5 +1,7 @@
 # wrapper around InfluxDBClient to handle dashboard and cells
 
+from collections import namedtuple
+
 from influxdb_client import InfluxDBClient, CellsService, DashboardsService, Dialect, QueryService, Query, rest
 from influxdb_client.client.flux_csv_parser import FluxCsvParser, FluxSerializationMode
 from influxdb_dashboard.cell import InfluxDBDashboardCellOutput
@@ -211,9 +213,9 @@ class InfluxDBDashboardView:
     self.id = dashboard_id
     self.ds = DashboardsService(self.client.api_client)
     info = self.ds.get_dashboards_id(self.id)
-    self.name = info.name
-    self.description = info.description
-    self.cells_info = info.cells
+    self.name = info.get('name', '')
+    self.description = info.get('description', '')
+    self.cells_info = list(map(lambda cell: namedtuple('cell', cell.keys())(*cell.values()), info['cells']))
     self.init_height()
     self._cells = None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests
-matplotlib
+# pin version of matplotlib at 3.3
+matplotlib>=3.3.2,<3.4
 pillow
 influxdb-client
 pytz


### PR DESCRIPTION
This solves the problem that internal APIs have changed in the DashboardService client.

It also pins matplotlib to 3.3 to ensure the warning present in matplotlib 3.4 does not show, at least until I spend more time and understand the problem.

Helps with #2 
